### PR TITLE
Pass chat web-search flag and query to backend

### DIFF
--- a/hooks/useChat.ts
+++ b/hooks/useChat.ts
@@ -398,8 +398,8 @@ export const useChat = (chatId: string) => {
             console.log('Reasoning chunk:', reasoningChunk);
             // TODO: Update UI with reasoning chunks
           },
-          false,
-          undefined,
+          Boolean(useWebSearch),
+          content,
           chatId
         );
 

--- a/hooks/useYandexGPT.ts
+++ b/hooks/useYandexGPT.ts
@@ -131,8 +131,8 @@ export const useYandexGPT = () => {
           messageContext: messageContext || [],
           model: selectedModel,
           reasoningMode: reasoningMode,
-          useWebSearch: false,
-          webSearchQuery: undefined,
+          useWebSearch: Boolean(useWebSearch),
+          webSearchQuery: webSearchQuery || prompt,
           chatId
         })
       });


### PR DESCRIPTION
### Motivation
- Ensure the backend receives the chat UI's web-search toggle and a non-empty query so the server can enter `WEB` mode and avoid fallback responses when web-search is intended.

### Description
- In `hooks/useYandexGPT.ts` send `useWebSearch: Boolean(useWebSearch)` and `webSearchQuery: webSearchQuery || prompt` to the `/api/generate-text` endpoint.
- In `hooks/useChat.ts` forward the chat form `useWebSearch` toggle and the original message `content` as the `webSearchQuery` when calling `generateText`.
- These changes allow the backend RAG/web-search logic to be triggered properly for chat messages.

### Testing
- Ran `npm run lint` which failed in this environment due to the `next lint` configuration interpreting a missing `lint` directory, unrelated to the changes.
- Ran `npm run build` which failed due to inability to fetch Google Fonts from `fonts.googleapis.com` in this environment, unrelated to the code modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0b228648c832998094da46e3dc462)