### PR TITLE
feat: add admin static pages with homepage selection

### DIFF
--- a/app/admin/static-pages/new/page.tsx
+++ b/app/admin/static-pages/new/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { Text } from '@gravity-ui/uikit';
+import StaticPageEditor from '@/app/components/static-pages/StaticPageEditor';
+
+export default function NewStaticPage() {
+  const searchParams = useSearchParams();
+  const pageId = searchParams?.get('pageId');
+  const [initialPage, setInitialPage] = useState<any>(null);
+  const [loading, setLoading] = useState(!!pageId);
+
+  useEffect(() => {
+    const loadPage = async () => {
+      if (!pageId) return;
+
+      const response = await fetch('/api/static-pages', { credentials: 'include' });
+      if (!response.ok) {
+        setLoading(false);
+        return;
+      }
+
+      const pages = await response.json();
+      const page = pages.find((p: any) => p.id === pageId);
+      setInitialPage(page ?? null);
+      setLoading(false);
+    };
+
+    void loadPage();
+  }, [pageId]);
+
+  if (loading) {
+    return <div className="container max-w-4xl mx-auto p-4"><Text>Loading...</Text></div>;
+  }
+
+  return <StaticPageEditor initialPage={initialPage ?? undefined} />;
+}

--- a/app/admin/static-pages/page.tsx
+++ b/app/admin/static-pages/page.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button, Card, Text } from '@gravity-ui/uikit';
+import { supabase } from '@/lib/supabase';
+
+export default function StaticPagesAdminPage() {
+  const router = useRouter();
+  const [allowed, setAllowed] = useState<boolean | null>(null);
+  const [pages, setPages] = useState<any[]>([]);
+
+  const loadData = async () => {
+    const response = await fetch('/api/static-pages', { credentials: 'include' });
+    if (response.ok) {
+      const data = await response.json();
+      setPages(data);
+    }
+  };
+
+  useEffect(() => {
+    const check = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.user) {
+        setAllowed(false);
+        return;
+      }
+
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('role')
+        .eq('id', session.user.id)
+        .single();
+
+      const canManage = profile?.role === 'admin' || profile?.role === 'editor';
+      setAllowed(canManage);
+
+      if (canManage) {
+        await loadData();
+      }
+    };
+
+    void check();
+  }, []);
+
+  const setHomepage = async (page: any) => {
+    await fetch(`/api/static-pages/${page.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ ...page, is_homepage: true })
+    });
+
+    await loadData();
+  };
+
+  if (allowed === null) {
+    return <div className="container max-w-4xl mx-auto p-4"><Text>Loading...</Text></div>;
+  }
+
+  if (!allowed) {
+    return <div className="container max-w-4xl mx-auto p-4"><Text>Access denied</Text></div>;
+  }
+
+  return (
+    <div className="container max-w-4xl mx-auto p-4 space-y-4">
+      <div className="flex justify-between items-center">
+        <Text variant="display-1">Static pages</Text>
+        <Button view="action" onClick={() => router.push('/admin/static-pages/new')}>Create page</Button>
+      </div>
+
+      {pages.map((page) => (
+        <Card key={page.id} className="p-4">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <Text variant="subheader-2">{page.title}</Text>
+              <Text variant="body-1" color="secondary">/{page.slug} • {page.published ? 'published' : 'draft'}</Text>
+              {page.is_homepage && <Text color="positive">Current homepage</Text>}
+            </div>
+            <div className="flex gap-2">
+              <Button view="outlined" onClick={() => router.push(`/admin/static-pages/new?pageId=${page.id}`)}>Edit</Button>
+              {!page.is_homepage && (
+                <Button view="normal" onClick={() => void setHomepage(page)}>Set as homepage</Button>
+              )}
+            </div>
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/app/api/public/main-page/route.ts
+++ b/app/api/public/main-page/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import type { Database } from '@/lib/types';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string;
+
+export async function GET() {
+  try {
+    const supabase = createClient<Database>(supabaseUrl, supabaseServiceKey, {
+      auth: { autoRefreshToken: false, persistSession: false }
+    });
+
+    const { data, error } = await (supabase as any)
+      .from('static_pages')
+      .select('*')
+      .eq('is_homepage', true)
+      .eq('published', true)
+      .single();
+
+    if (error || !data) {
+      return NextResponse.json({ page: null }, { status: 200 });
+    }
+
+    return NextResponse.json({ page: data });
+  } catch (error) {
+    console.error('Error getting main static page:', error);
+    return NextResponse.json({ page: null }, { status: 200 });
+  }
+}

--- a/app/api/static-pages/[id]/route.ts
+++ b/app/api/static-pages/[id]/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import type { Database } from '@/lib/types';
+import { withAuth } from '@/app/auth/withApiKeyAuth';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string;
+
+const isAdminOrEditor = async (userId: string) => {
+  const supabase = createClient<Database>(supabaseUrl, supabaseServiceKey, {
+    auth: { autoRefreshToken: false, persistSession: false }
+  });
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', userId)
+    .single();
+
+  return profile?.role === 'admin' || profile?.role === 'editor';
+};
+
+export const PUT = withAuth(async (request: NextRequest, user: { id: string }) => {
+  try {
+    const allowed = await isAdminOrEditor(user.id);
+    if (!allowed) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+    }
+
+    const id = new URL(request.url).pathname.split('/').pop();
+    if (!id) {
+      return NextResponse.json({ error: 'Page ID is required' }, { status: 400 });
+    }
+
+    const { title, content, excerpt, slug, featured_image, published, is_homepage } = await request.json();
+
+    if (!title?.trim() || !content?.trim() || !slug?.trim()) {
+      return NextResponse.json({ error: 'Title, content and slug are required' }, { status: 400 });
+    }
+
+    const supabase = createClient<Database>(supabaseUrl, supabaseServiceKey, {
+      auth: { autoRefreshToken: false, persistSession: false }
+    });
+
+    if (is_homepage) {
+      await (supabase as any)
+        .from('static_pages')
+        .update({ is_homepage: false, updated_at: new Date().toISOString() })
+        .eq('is_homepage', true)
+        .neq('id', id);
+    }
+
+    const { data, error } = await (supabase as any)
+      .from('static_pages')
+      .update({
+        title,
+        content,
+        excerpt,
+        slug,
+        featured_image,
+        published: !!published,
+        is_homepage: !!is_homepage,
+        updated_at: new Date().toISOString()
+      })
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    return NextResponse.json(data);
+  } catch (error: any) {
+    console.error('Error updating static page:', error);
+    return NextResponse.json({ error: error?.message || 'Failed to update static page' }, { status: 500 });
+  }
+});

--- a/app/api/static-pages/route.ts
+++ b/app/api/static-pages/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import type { Database } from '@/lib/types';
+import { withAuth } from '@/app/auth/withApiKeyAuth';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string;
+
+const isAdminOrEditor = async (userId: string) => {
+  const supabase = createClient<Database>(supabaseUrl, supabaseServiceKey, {
+    auth: { autoRefreshToken: false, persistSession: false }
+  });
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', userId)
+    .single();
+
+  return profile?.role === 'admin' || profile?.role === 'editor';
+};
+
+export const GET = withAuth(async (_request: NextRequest, user: { id: string }) => {
+  try {
+    const allowed = await isAdminOrEditor(user.id);
+    if (!allowed) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+    }
+
+    const supabase = createClient<Database>(supabaseUrl, supabaseServiceKey, {
+      auth: { autoRefreshToken: false, persistSession: false }
+    });
+
+    const { data, error } = await (supabase as any)
+      .from('static_pages')
+      .select('*')
+      .order('created_at', { ascending: false });
+
+    if (error) throw error;
+
+    return NextResponse.json(data ?? []);
+  } catch (error) {
+    console.error('Error getting static pages:', error);
+    return NextResponse.json({ error: 'Failed to get static pages' }, { status: 500 });
+  }
+});
+
+export const POST = withAuth(async (request: NextRequest, user: { id: string }) => {
+  try {
+    const allowed = await isAdminOrEditor(user.id);
+    if (!allowed) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+    }
+
+    const { title, content, excerpt, slug, featured_image, published, is_homepage } = await request.json();
+
+    if (!title?.trim() || !content?.trim() || !slug?.trim()) {
+      return NextResponse.json({ error: 'Title, content and slug are required' }, { status: 400 });
+    }
+
+    const supabase = createClient<Database>(supabaseUrl, supabaseServiceKey, {
+      auth: { autoRefreshToken: false, persistSession: false }
+    });
+
+    if (is_homepage) {
+      await (supabase as any).from('static_pages').update({ is_homepage: false }).eq('is_homepage', true);
+    }
+
+    const { data, error } = await (supabase as any)
+      .from('static_pages')
+      .insert({
+        title,
+        content,
+        excerpt,
+        slug,
+        featured_image,
+        published: !!published,
+        is_homepage: !!is_homepage,
+        author_id: user.id,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString()
+      })
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    return NextResponse.json(data, { status: 201 });
+  } catch (error: any) {
+    console.error('Error creating static page:', error);
+    return NextResponse.json({ error: error?.message || 'Failed to create static page' }, { status: 500 });
+  }
+});

--- a/app/components/static-pages/MainPageSection.tsx
+++ b/app/components/static-pages/MainPageSection.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { Text } from '@gravity-ui/uikit';
+import TipTapContent from '@/app/components/blog/TipTapContent';
+
+export default function MainPageSection() {
+  const [page, setPage] = useState<any | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      const response = await fetch('/api/public/main-page', { credentials: 'include' });
+      if (response.ok) {
+        const data = await response.json();
+        setPage(data.page ?? null);
+      }
+      setLoaded(true);
+    };
+
+    void load();
+  }, []);
+
+  if (!loaded) return null;
+  if (!page) return null;
+
+  return (
+    <section className="mt-8">
+      <Text variant="display-1">{page.title}</Text>
+      <TipTapContent content={page.content} />
+    </section>
+  );
+}

--- a/app/components/static-pages/MainPageSection.tsx
+++ b/app/components/static-pages/MainPageSection.tsx
@@ -1,10 +1,14 @@
 "use client";
 
-import { useEffect, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 import { Text } from '@gravity-ui/uikit';
 import TipTapContent from '@/app/components/blog/TipTapContent';
 
-export default function MainPageSection() {
+interface MainPageSectionProps {
+  fallback?: ReactNode;
+}
+
+export default function MainPageSection({ fallback = null }: MainPageSectionProps) {
   const [page, setPage] = useState<any | null>(null);
   const [loaded, setLoaded] = useState(false);
 
@@ -22,7 +26,7 @@ export default function MainPageSection() {
   }, []);
 
   if (!loaded) return null;
-  if (!page) return null;
+  if (!page) return <>{fallback}</>;
 
   return (
     <section className="mt-8">

--- a/app/components/static-pages/StaticPageEditor.tsx
+++ b/app/components/static-pages/StaticPageEditor.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button, Checkbox, Text } from '@gravity-ui/uikit';
+import PostMetadata from '@/app/components/blog/editor/PostMetadata';
+import TipTapEditor from '@/app/components/blog/TipTapEditor';
+import { useTipTapEditor } from '@/hooks/useTipTapEditor';
+
+interface StaticPageEditorProps {
+  initialPage?: any;
+}
+
+export default function StaticPageEditor({ initialPage }: StaticPageEditorProps) {
+  const router = useRouter();
+  const [isHomepage, setIsHomepage] = useState<boolean>(initialPage?.is_homepage ?? false);
+
+  const {
+    title,
+    setTitle,
+    slug,
+    setSlug,
+    excerpt,
+    setExcerpt,
+    tipTapContent,
+    featuredImageUrl,
+    showFeaturedImage,
+    setShowFeaturedImage,
+    isLoading,
+    imagePrompt,
+    setImagePrompt,
+    showGenerationDialog,
+    setShowGenerationDialog,
+    generatedImagePreview,
+    activeImageTab,
+    setActiveImageTab,
+    isGenerating,
+    isUploading,
+    handleContentChange,
+    handleFeaturedImageUpload,
+    handleDeleteFeaturedImage,
+    handleGenerateImage,
+    handleApplyGeneratedImage,
+    handleSelectGalleryImage
+  } = useTipTapEditor(initialPage);
+
+  const savePage = async (publish: boolean) => {
+    const payload = {
+      title,
+      slug,
+      excerpt,
+      content: tipTapContent,
+      featured_image: featuredImageUrl,
+      published: publish,
+      is_homepage: isHomepage
+    };
+
+    const response = await fetch(initialPage?.id ? `/api/static-pages/${initialPage.id}` : '/api/static-pages', {
+      method: initialPage?.id ? 'PUT' : 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.error || 'Не удалось сохранить страницу');
+    }
+
+    router.push('/admin/static-pages');
+    router.refresh();
+  };
+
+  return (
+    <div className="container max-w-4xl mx-auto p-4 space-y-6">
+      <Text variant="display-1">Static page editor</Text>
+
+      <PostMetadata
+        title={title}
+        setTitle={setTitle}
+        slug={slug}
+        setSlug={setSlug}
+        excerpt={excerpt}
+        setExcerpt={setExcerpt}
+        featuredImageUrl={featuredImageUrl}
+        showFeaturedImage={showFeaturedImage}
+        setShowFeaturedImage={setShowFeaturedImage}
+        onDeleteFeaturedImage={handleDeleteFeaturedImage}
+        onUploadFeaturedImage={handleFeaturedImageUpload}
+        onGenerateImage={handleGenerateImage}
+        onApplyGeneratedImage={handleApplyGeneratedImage}
+        onSelectGalleryImage={handleSelectGalleryImage}
+        isGenerating={isGenerating}
+        isUploading={isUploading}
+        imagePrompt={imagePrompt}
+        setImagePrompt={setImagePrompt}
+        generatedImagePreview={generatedImagePreview}
+        activeImageTab={activeImageTab}
+        setActiveImageTab={setActiveImageTab}
+        showGenerationDialog={showGenerationDialog}
+        setShowGenerationDialog={setShowGenerationDialog}
+      />
+
+      <div className="p-4 border rounded-md">
+        <Checkbox checked={isHomepage} onUpdate={setIsHomepage} content="Use this page as main homepage" />
+      </div>
+
+      <TipTapEditor content={tipTapContent} onChange={handleContentChange} placeholder="Type static page content..." />
+
+      <div className="flex gap-4">
+        <Button size="l" view="action" loading={isLoading} onClick={() => void savePage(true)}>
+          Publish page
+        </Button>
+        <Button size="l" view="outlined" loading={isLoading} onClick={() => void savePage(false)}>
+          Save as draft
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,9 +11,14 @@ export default function Home() {
   return (
     <main className="container mx-auto px-4 max-w-4xl">
       <div>
-        <MainPageSection />
-        <HomeClient />
-        <ShowApp />
+        <MainPageSection
+          fallback={(
+            <>
+              <HomeClient />
+              <ShowApp />
+            </>
+          )}
+        />
       </div>
     </main>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import HomeClient from './HomeClient';
 import ShowApp from './components/show-app/ShowApp';
+import MainPageSection from './components/static-pages/MainPageSection';
 
 export const metadata: Metadata = {
   title: 'Dmitrii Gareev, Product designer',
@@ -10,6 +11,7 @@ export default function Home() {
   return (
     <main className="container mx-auto px-4 max-w-4xl">
       <div>
+        <MainPageSection />
         <HomeClient />
         <ShowApp />
       </div>

--- a/migrations/create_static_pages_table.sql
+++ b/migrations/create_static_pages_table.sql
@@ -1,0 +1,52 @@
+-- Static pages for admin/editor managed website pages
+create table if not exists public.static_pages (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  slug text not null unique,
+  excerpt text,
+  content text not null,
+  featured_image text,
+  published boolean not null default false,
+  is_homepage boolean not null default false,
+  author_id uuid not null references public.profiles(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint static_pages_slug_format check (slug ~ '^[a-z0-9-]+$')
+);
+
+create unique index if not exists static_pages_single_homepage_idx
+on public.static_pages (is_homepage)
+where is_homepage = true;
+
+create index if not exists static_pages_author_id_idx on public.static_pages(author_id);
+create index if not exists static_pages_published_idx on public.static_pages(published);
+
+alter table public.static_pages enable row level security;
+
+drop policy if exists "Public can read published static pages" on public.static_pages;
+create policy "Public can read published static pages"
+on public.static_pages
+for select
+using (published = true);
+
+drop policy if exists "Authenticated can create static pages" on public.static_pages;
+create policy "Authenticated can create static pages"
+on public.static_pages
+for insert
+to authenticated
+with check (auth.uid() = author_id);
+
+drop policy if exists "Authors can update own static pages" on public.static_pages;
+create policy "Authors can update own static pages"
+on public.static_pages
+for update
+to authenticated
+using (auth.uid() = author_id)
+with check (auth.uid() = author_id);
+
+drop policy if exists "Authors can delete own static pages" on public.static_pages;
+create policy "Authors can delete own static pages"
+on public.static_pages
+for delete
+to authenticated
+using (auth.uid() = author_id);


### PR DESCRIPTION
### Motivation

- Provide a simple admin/editor UI to create and manage static pages for the site and allow selecting one page as the site’s main homepage. 
- Reuse the existing blog post editor flow and content format so pages can be authored with the same TipTap/metadata tools.

### Description

- Add a new `static_pages` migration with fields for `title`, `slug`, `content`, `featured_image`, `published`, `is_homepage`, timestamps, a slug format check, indexes, and RLS policies to allow public read of published pages and author-based writes.  
- Implement authenticated admin APIs: `GET/POST /api/static-pages` for listing/creating and `PUT /api/static-pages/[id]` for updating, including role checks for `admin`/`editor` and logic to reset the previous homepage when `is_homepage=true`.  
- Add a public API `GET /api/public/main-page` that returns the currently published homepage for rendering on the site root.  
- Add admin UI and editor components: `/admin/static-pages` list, `/admin/static-pages/new` create/edit page (reuses blog `PostMetadata` + `TipTapEditor`), `StaticPageEditor` component with a checkbox to mark page as homepage, and `MainPageSection` component to render the homepage on `/`.

### Testing

- Ran `npm run lint` which failed due to project lint invocation issues (`next lint` error: "Invalid project directory provided ... /lint").  
- Ran `npx tsc --noEmit` which failed because of pre-existing unrelated TypeScript errors in test files under `features/*/__tests__`.  
- Ran `npx eslint ...` against the new files which failed because the repository uses ESLint v9 flat config and no `eslint.config.*` was present in this environment.  
- Attempted `npm run dev` and a Playwright screenshot but dev server rendering failed due to missing Supabase environment variables and external font download issues, so UI runtime verification (screenshot) could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b123d6b3ec8329ae370655185276bf)