### PR TITLE
Скрывать мобильную навигацию на страницах чата

### DIFF
--- a/app/components/Navigation/Navigation.css
+++ b/app/components/Navigation/Navigation.css
@@ -226,6 +226,10 @@
 
 /* Mobile Navigation */
 @media (max-width: 767px) {
+  .navigation--chat-route {
+    display: none;
+  }
+
   .navigation {
     position: fixed;
     bottom: 16px;

--- a/app/components/Navigation/Navigation.tsx
+++ b/app/components/Navigation/Navigation.tsx
@@ -35,6 +35,7 @@ const Navigation: React.FC = () => {
   const [isMobileViewport, setIsMobileViewport] = useState(false);
   const isLeftAnchoredWidgetsPanel = navigationPosition === 'left' && !isMobileViewport;
   const isBottomAnchoredWidgetsPanel = navigationPosition === 'bottom' || isMobileViewport;
+  const isChatRoute = pathname?.startsWith('/chat') ?? false;
 
   // Function to determine active item based on current path
   const getActiveItemFromPath = (pathname: string): string => {
@@ -228,7 +229,7 @@ const Navigation: React.FC = () => {
 
   return (
     <>
-      <nav className={`navigation navigation--${navigationPosition}`}>
+      <nav className={`navigation navigation--${navigationPosition} ${isChatRoute ? 'navigation--chat-route' : ''}`}>
         <div className="nav-container">
           <div className="logo-area">
             <div className="logo-wrapper">


### PR DESCRIPTION
### Motivation
- На мобильных устройствах глобальная панель навигации перекрывает интерфейс чата, поэтому нужно скрывать её на маршрутах `/chat` без изменения поведения на десктопе.

### Description
- В `app/components/Navigation/Navigation.tsx` добавлено определение маршрута чата через `isChatRoute = pathname?.startsWith('/chat') ?? false` и применяется класс `navigation--chat-route` на корневом элементе навигации.`
- В `app/components/Navigation/Navigation.css` внутри медиа-запроса для мобильных устройств добавлено правило `.navigation--chat-route { display: none; }`, которое скрывает навигацию только на мобильных ширинах.

### Testing
- Выполнена проверка изменений командой `git diff --check`, проблем не выявлено.;
- Запуск `npm run lint` завершился с ошибкой из-за конфигурации `next lint` в этой среде и не связан с внесёнными изменениями; 
- `npx tsc --noEmit` завершился с ошибками типизации в существующих тестовых фикстурах (не связанных с изменёнными файлами), поэтому типовую проверку полностью пройти не удалось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcfe4ec6f88329b12a7e2a4b70530e)