### PR TITLE
Move chat action controls to separate toolbar row

### DIFF
--- a/app/components/chat/ChatMessageForm.css
+++ b/app/components/chat/ChatMessageForm.css
@@ -20,20 +20,35 @@
 
 .chat-message-form__input-row {
   display: flex;
-  align-items: flex-end;
+  flex-direction: column;
+  align-items: stretch;
   gap: 8px;
 }
 
 .chat-message-form__textarea {
   /* Стили для текстового поля */
+  width: 100%;
   transition: all 0.2s ease;
 }
 
 .chat-message-form__toolbar {
-  /* Стили для панели инструментов с кнопками */
+  /* Стили для строки с дополнительными кнопками и отправкой */
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 8px;
+  width: 100%;
+}
+
+.chat-message-form__tools {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chat-message-form__button--submit {
+  flex-shrink: 0;
 }
 
 /* Анимации */

--- a/app/components/chat/ChatMessageForm.tsx
+++ b/app/components/chat/ChatMessageForm.tsx
@@ -72,8 +72,8 @@ export const ChatMessageForm = ({
         </div>
       )}
 
-      {/* Message input and buttons */}
-      <div className="chat-message-form__input-row flex items-end gap-2">
+      {/* Message input and controls */}
+      <div className="chat-message-form__input-row">
         <TextArea
           ref={textareaRef}
           value={messageText}
@@ -85,47 +85,50 @@ export const ChatMessageForm = ({
           className="chat-message-form__textarea"
         />
         <div className="chat-message-form__toolbar">
-          {/* File upload button - always visible, on the left */}
-          <FileUploader
-            files={attachedFiles}
-            onFilesChange={setAttachedFiles}
-            disabled={disabled || isMessageSending}
-            maxFiles={3}
-            maxFileSize={10 * 1024 * 1024} // 10MB
-            compact={true}
-          />
+          <div className="chat-message-form__tools">
+            {/* File upload button - always visible, on the left */}
+            <FileUploader
+              files={attachedFiles}
+              onFilesChange={setAttachedFiles}
+              disabled={disabled || isMessageSending}
+              maxFiles={3}
+              maxFileSize={10 * 1024 * 1024} // 10MB
+              compact={true}
+            />
 
-          <Button
-            type="button"
-            size="m"
-            view={useWebSearch ? "action" : "outlined"}
-            onClick={onToggleWebSearch}
-            title={useWebSearch ? "Web-search enabled" : "Use web-search"}
-            disabled={disabled}
-            className="chat-message-form__button chat-message-form__button--web-search"
-          >
-            <Icon data={Globe} size={16} />
-          </Button>
-
-          {/* Show reasoning button only for YandexGPT */}
-          {selectedModel === 'yandexgpt' && (
             <Button
               type="button"
               size="m"
-              view={reasoningMode ? "action" : "outlined"}
-              onClick={() => setReasoningMode(!reasoningMode)}
-              title={reasoningMode ? "Disable reasoning mode" : "Enable reasoning mode"}
+              view={useWebSearch ? "action" : "outlined"}
+              onClick={onToggleWebSearch}
+              title={useWebSearch ? "Web-search enabled" : "Use web-search"}
               disabled={disabled}
-              className={`chat-message-form__button chat-message-form__button--reasoning ${reasoningMode ? 'active' : ''}`}
+              className="chat-message-form__button chat-message-form__button--web-search"
             >
-              <Icon data={Bulb} size={16} />
+              <Icon data={Globe} size={16} />
             </Button>
-          )}
+
+            {/* Show reasoning button only for YandexGPT */}
+            {selectedModel === 'yandexgpt' && (
+              <Button
+                type="button"
+                size="m"
+                view={reasoningMode ? "action" : "outlined"}
+                onClick={() => setReasoningMode(!reasoningMode)}
+                title={reasoningMode ? "Disable reasoning mode" : "Enable reasoning mode"}
+                disabled={disabled}
+                className={`chat-message-form__button chat-message-form__button--reasoning ${reasoningMode ? 'active' : ''}`}
+              >
+                <Icon data={Bulb} size={16} />
+              </Button>
+            )}
+          </div>
 
           <Button
             type="submit"
             size="m"
             view="action"
+            className="chat-message-form__button chat-message-form__button--submit"
             disabled={(!messageText.trim() && attachedFiles.length === 0) || isMessageSending || disabled}
           >
             {isMessageSending ? (

--- a/features/chat-aikit/ui/AikitChatPanel.tsx
+++ b/features/chat-aikit/ui/AikitChatPanel.tsx
@@ -169,6 +169,7 @@ export function AikitChatPanel({ chatId }: { chatId: string }) {
         shouldParseIncompleteMarkdown
         showActionsOnHover
         promptInputProps={{
+          view: "full",
           topPanel:
             attachedFiles.length > 0
               ? {


### PR DESCRIPTION
### Motivation
- Improve chat input layout so auxiliary buttons and the send button are placed on a separate row below the text area for better alignment and responsive behavior.

### Description
- Update `app/components/chat/ChatMessageForm.tsx` to render the textarea on its own row and group auxiliary controls into a new `.chat-message-form__tools` container while keeping the submit button aligned to the right in a separate toolbar row.
- Adjust `app/components/chat/ChatMessageForm.css` to make `.chat-message-form__input-row` a column, make the textarea span full width, and style `.chat-message-form__toolbar` with `justify-content: space-between` plus a new `.chat-message-form__tools` flex wrapper and `.chat-message-form__button--submit` rule.

### Testing
- Ran `npm run lint`, which failed due to the local `next lint` configuration referencing an invalid project directory.
- Ran `npx tsc --noEmit`, which failed because of existing unrelated TypeScript errors in test fixtures (`features/group-management` and `features/subscriber-management`).
- Ran `npm run build`, which failed in this environment because `next/font` could not fetch Google Fonts during the production build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00e84cea148329a84f125dd84f68cb)