### PR TITLE
Restyle home page as old Unix terminal

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -1,7 +1,6 @@
 "use client"
 
-import { Text, Icon, Link, Button, Label } from '@gravity-ui/uikit';
-import { Globe } from '@gravity-ui/icons';
+import { Text, Link, Button, Label } from '@gravity-ui/uikit';
 import GradientHoverImage from './components/GradientHoverImage';
 import { useI18n } from './contexts/I18nContext';
 
@@ -34,13 +33,22 @@ export default function HomeClient() {
   const { t } = useI18n();
 
   return (
-    <div className="home-page page-container">
+    <div className="home-page page-container" data-terminal="dmitrii.gareev:/home">
+      <div className="home-terminal-bar" aria-hidden="true">
+        <span className="home-terminal-led" />
+        <span>tty0</span>
+        <span>unix portfolio monitor</span>
+        <span>115200 baud</span>
+      </div>
+
       <section className="home-hero content-container" aria-labelledby="home-hero-title">
         <div className="home-hero__content">
           <div className="home-eyebrow">
             <Label theme="info">{t('home.eyebrow')}</Label>
             <span>{t('home.availability')}</span>
           </div>
+
+          <div className="home-command" aria-hidden="true">$ cat ./profile.txt</div>
 
           <Text id="home-hero-title" className="home-title" variant="display-1">
             {t('home.bio.prefix')}{' '}
@@ -76,6 +84,7 @@ export default function HomeClient() {
             <span className="home-hero-card__dot" />
             <Text variant="caption-2" color="secondary">{t('home.hero.cardKicker')}</Text>
           </div>
+          <div className="home-command" aria-hidden="true">$ run ./positioning --fast</div>
           <Text variant="header-2">{t('home.hero.cardTitle')}</Text>
           <Text variant="body-2" color="secondary">{t('home.hero.cardText')}</Text>
           <div className="home-metrics">
@@ -91,6 +100,7 @@ export default function HomeClient() {
 
       <section className="home-section content-container" aria-labelledby="home-strengths-title">
         <div className="home-section__header">
+          <div className="home-command" aria-hidden="true">$ ls ./team-output</div>
           <Text id="home-strengths-title" variant="header-1">{t('home.strengths.title')}</Text>
           <Text variant="body-2" color="secondary">{t('home.strengths.description')}</Text>
         </div>
@@ -107,13 +117,14 @@ export default function HomeClient() {
 
       <section className="home-section home-section--highlight content-container" aria-labelledby="home-outcomes-title">
         <div className="home-section__header">
+          <div className="home-command" aria-hidden="true">$ tail -f ./workflow.log</div>
           <Text id="home-outcomes-title" variant="header-1">{t('home.outcomes.title')}</Text>
           <Text variant="body-2" color="secondary">{t('home.outcomes.description')}</Text>
         </div>
         <div className="home-outcomes">
           {outcomes.map((key) => (
             <div className="home-outcome" key={key}>
-              <span className="home-outcome__check">✓</span>
+              <span className="home-outcome__check">OK</span>
               <Text variant="body-2">{t(key)}</Text>
             </div>
           ))}
@@ -122,6 +133,7 @@ export default function HomeClient() {
 
       <section className="home-section content-container" aria-labelledby="home-proof-title">
         <div className="home-section__header">
+          <div className="home-command" aria-hidden="true">$ grep -R "why" ./2026</div>
           <Text id="home-proof-title" variant="header-1">{t('home.proof.title')}</Text>
           <Text variant="body-2" color="secondary">{t('home.proof.description')}</Text>
         </div>
@@ -137,6 +149,7 @@ export default function HomeClient() {
 
       <section className="home-cta content-container" aria-labelledby="home-cta-title">
         <div>
+          <div className="home-command" aria-hidden="true">$ ./connect --channel=telegram</div>
           <Text id="home-cta-title" variant="header-1">{t('home.finalCta.title')}</Text>
           <Text variant="body-2" color="secondary">{t('home.finalCta.text')}</Text>
         </div>
@@ -152,13 +165,13 @@ export default function HomeClient() {
 
       <div className="links-container home-socials" aria-label={t('home.social.label')}>
         <Link href="https://x.com/gareev" target="_blank" rel="noopener noreferrer">
-          <Text className="LinkHover" variant="subheader-3"><Icon data={Globe} size={16} /> {t('home.social.x')} </Text>
+          <Text className="LinkHover" variant="subheader-3">{t('home.social.x')}</Text>
         </Link>
         <Link href="https://t.me/gareev45" target="_blank" rel="noopener noreferrer">
-          <Text className="LinkHover" variant="subheader-3"><Icon data={Globe} size={16} /> {t('home.social.telegram')} </Text>
+          <Text className="LinkHover" variant="subheader-3">{t('home.social.telegram')}</Text>
         </Link>
         <Link href="https://www.linkedin.com/in/dmitrii-gareev-234146253" target="_blank" rel="noopener noreferrer">
-          <Text className="LinkHover" variant="subheader-3"><Icon data={Globe} size={16} /> {t('home.social.linkedin')} </Text>
+          <Text className="LinkHover" variant="subheader-3">{t('home.social.linkedin')}</Text>
         </Link>
       </div>
     </div>

--- a/app/components/MyProjects/MyProjects.tsx
+++ b/app/components/MyProjects/MyProjects.tsx
@@ -1,38 +1,36 @@
 'use client';
-import '../../components/components.css';
-import {Button, Breadcrumbs, Card, Text, Label, Skeleton} from '@gravity-ui/uikit';
+
+import { Card, Text } from '@gravity-ui/uikit';
 import Link from 'next/link';
-import { useRef, useEffect } from 'react';
-import { gsap } from 'gsap';
 
 const MyProjects = () => {
-
   return (
     <div className="group-container">
-    <Link href="/projects/uploader" rel="noopener noreferrer">
-        <Card type="container" size="l" className='project-card'>
+      <Link href="/projects/uploader" rel="noopener noreferrer">
+        <Card type="container" size="l" className="project-card">
           <Text color="primary" variant="header-1">Image Syncer</Text>
         </Card>
-    </Link>
-    <Link href="/projects/yaart" rel="noopener noreferrer">
-        <Card type="container" size="l" className='project-card'>
+      </Link>
+      <Link href="/projects/yaart" rel="noopener noreferrer">
+        <Card type="container" size="l" className="project-card">
           <Text color="primary" variant="header-1">Image Generator</Text>
         </Card>
-    </Link>
-        <Link href="/chat" rel="noopener noreferrer">
+      </Link>
+      <Link href="/chat" rel="noopener noreferrer">
         <Card
           type="container"
           size="l"
           view="filled"
           theme="info"
-          className='project-card parallax-card'
+          className="project-card parallax-card"
         >
-          <div className='flex row gap-2'>
-          <Text color="primary" variant="header-1">AI Chat </Text>
+          <div className="flex row gap-2">
+            <Text color="primary" variant="header-1">AI Chat</Text>
           </div>
         </Card>
-    </Link>
+      </Link>
     </div>
   );
-}
+};
+
 export default MyProjects;

--- a/app/components/show-app/ShowApp.tsx
+++ b/app/components/show-app/ShowApp.tsx
@@ -1,16 +1,16 @@
 'use client';
+
 import '../../components/components.css';
-import {Button, Breadcrumbs, Card, Text, Label, Skeleton} from '@gravity-ui/uikit';
+import { Text } from '@gravity-ui/uikit';
 import MyProjects from '../MyProjects/MyProjects';
-import Link from 'next/link';
 
 const ShowApp = () => {
-
   return (
     <div className="group-container">
-        <Text className="mt-14" variant="header-2">Pet projects</Text>
-        <MyProjects />
+      <Text className="mt-14" variant="header-2">Pet projects</Text>
+      <MyProjects />
     </div>
   );
-}
+};
+
 export default ShowApp;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -184,8 +184,95 @@ a {
 }
 
 .home-page {
-  gap: clamp(32px, 5vw, 72px);
-  padding: clamp(16px, 3vw, 40px) 0 24px;
+  position: relative;
+  isolation: isolate;
+  gap: clamp(18px, 3vw, 34px);
+  overflow: hidden;
+  padding: clamp(16px, 3vw, 34px);
+  color: #49ff78;
+  font-family: var(--font-mono), "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  text-shadow: 0 0 7px rgba(73, 255, 120, 0.62);
+  background:
+    linear-gradient(90deg, rgba(73, 255, 120, 0.07) 1px, transparent 1px),
+    linear-gradient(180deg, rgba(73, 255, 120, 0.045) 1px, transparent 1px),
+    radial-gradient(circle at 18% 8%, rgba(73, 255, 120, 0.18), transparent 24%),
+    radial-gradient(circle at 86% 72%, rgba(0, 112, 58, 0.28), transparent 34%),
+    #07110c;
+  background-size: 36px 36px, 100% 4px, auto, auto, auto;
+  border: 1px solid rgba(73, 255, 120, 0.38);
+  border-radius: 2px;
+  box-shadow:
+    inset 0 0 72px rgba(4, 0, 0, 0.8),
+    inset 0 0 18px rgba(73, 255, 120, 0.18),
+    0 24px 90px rgba(0, 0, 0, 0.42);
+}
+
+.home-page::before,
+.home-page::after {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  content: "";
+}
+
+.home-page::before {
+  opacity: 0.24;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.09) 50%, rgba(0, 0, 0, 0.22) 50%),
+    linear-gradient(90deg, rgba(255, 0, 0, 0.12), rgba(0, 255, 0, 0.07), rgba(0, 0, 255, 0.12));
+  background-size: 100% 3px, 5px 100%;
+  mix-blend-mode: screen;
+}
+
+.home-page::after {
+  opacity: 0.2;
+  background:
+    repeating-radial-gradient(circle at 10% 20%, rgba(255, 255, 255, 0.3) 0 1px, transparent 1px 3px),
+    linear-gradient(180deg, transparent 0%, rgba(73, 255, 120, 0.12) 48%, transparent 52%, rgba(16, 73, 39, 0.18) 100%);
+  filter: blur(0.4px);
+}
+
+.home-page [class*="g-text"] {
+  font-family: inherit;
+  color: inherit;
+}
+
+.home-page .g-text_color_secondary {
+  color: rgba(148, 255, 170, 0.78);
+}
+
+.home-terminal-bar {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  gap: 12px;
+  width: 100%;
+  max-width: 1040px;
+  padding: 10px 12px;
+  color: rgba(148, 255, 170, 0.82);
+  font-size: 12px;
+  line-height: 1;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  border: 1px solid rgba(73, 255, 120, 0.32);
+  background: rgba(3, 16, 8, 0.76);
+}
+
+.home-terminal-led {
+  width: 8px;
+  height: 8px;
+  margin-top: 1px;
+  border-radius: 50%;
+  background: #ff1744;
+  box-shadow: 0 0 10px rgba(255, 23, 68, 0.9);
+}
+
+.home-command {
+  color: rgba(190, 255, 199, 0.88);
+  font-size: 13px;
+  line-height: 1.4;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .content-container {
@@ -233,28 +320,53 @@ a {
   display: grid;
   grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.65fr);
   align-items: stretch;
-  gap: clamp(20px, 4vw, 40px);
+  gap: clamp(16px, 3vw, 28px);
   min-height: 520px;
 }
 
 .home-hero__content,
 .home-hero-card,
 .home-section,
-.home-cta {
-  border: 1px solid var(--g-color-line-generic);
-  border-radius: clamp(24px, 4vw, 40px);
+.home-cta,
+.links-container,
+.home-page + .group-container,
+.home-page ~ .group-container .project-card {
+  border: 1px solid rgba(73, 255, 120, 0.42);
+  border-radius: 0;
   background:
-    radial-gradient(circle at 15% 15%, rgba(82, 130, 255, 0.14), transparent 32%),
-    var(--g-color-base-float);
-  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.08);
+    linear-gradient(180deg, rgba(73, 255, 120, 0.045), transparent 28%),
+    rgba(2, 19, 9, 0.72);
+  box-shadow:
+    inset 0 0 22px rgba(73, 255, 120, 0.07),
+    0 0 0 1px rgba(0, 0, 0, 0.42);
+}
+
+.home-hero__content,
+.home-hero-card,
+.home-section,
+.home-cta {
+  position: relative;
+}
+
+.home-hero__content::before,
+.home-hero-card::before,
+.home-section::before,
+.home-cta::before {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  color: rgba(73, 255, 120, 0.28);
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  content: "READY";
 }
 
 .home-hero__content {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 28px;
-  padding: clamp(28px, 5vw, 56px);
+  gap: 24px;
+  padding: clamp(24px, 5vw, 50px);
 }
 
 .home-eyebrow,
@@ -268,23 +380,67 @@ a {
 }
 
 .home-eyebrow {
-  color: var(--g-color-text-secondary);
+  color: rgba(148, 255, 170, 0.78);
+  text-transform: uppercase;
+}
+
+.home-page .g-label,
+.home-page .g-label_theme_info {
+  color: #07110c;
+  font-family: inherit;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: #49ff78;
+  border-radius: 0;
+  box-shadow: 0 0 14px rgba(73, 255, 120, 0.38);
 }
 
 .home-title {
   display: inline;
   max-width: 920px;
-  letter-spacing: -0.05em;
+  letter-spacing: -0.03em;
+  line-height: 0.98;
   text-wrap: balance;
+}
+
+.home-title::after {
+  display: inline-block;
+  width: 0.58em;
+  height: 0.9em;
+  margin-left: 0.16em;
+  vertical-align: -0.08em;
+  background: #49ff78;
+  box-shadow: 0 0 12px rgba(73, 255, 120, 0.7);
+  content: "";
+  animation: terminal-cursor 1s steps(2, end) infinite;
 }
 
 .home-subtitle {
   max-width: 760px;
-  line-height: 1.55;
+  line-height: 1.6;
 }
 
 .home-actions {
   margin-top: 8px;
+}
+
+.home-page .g-button {
+  --g-button-border-radius: 0;
+  font-family: inherit;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.home-page .g-button_view_action {
+  color: #061107;
+  background: #49ff78;
+  box-shadow: 0 0 18px rgba(73, 255, 120, 0.3);
+}
+
+.home-page .g-button_view_outlined {
+  color: #49ff78;
+  border-color: rgba(73, 255, 120, 0.62);
+  background: rgba(73, 255, 120, 0.04);
 }
 
 .home-hero-card {
@@ -293,18 +449,15 @@ a {
   justify-content: space-between;
   gap: 20px;
   min-height: 360px;
-  padding: clamp(24px, 3vw, 36px);
-  background:
-    linear-gradient(155deg, var(--g-color-base-positive-light) 0%, var(--g-color-base-float) 58%),
-    var(--g-color-base-float);
+  padding: clamp(22px, 3vw, 34px);
 }
 
 .home-hero-card__dot {
   width: 10px;
   height: 10px;
   border-radius: 999px;
-  background: var(--g-color-text-positive);
-  box-shadow: 0 0 0 8px var(--g-color-base-positive-light);
+  background: #49ff78;
+  box-shadow: 0 0 12px rgba(73, 255, 120, 0.95);
 }
 
 .home-metrics {
@@ -315,21 +468,19 @@ a {
 .home-metric {
   display: grid;
   gap: 2px;
-  padding: 16px;
-  border-radius: var(--g-border-radius-xl);
-  background-color: color-mix(in srgb, var(--g-color-base-background) 72%, transparent);
-  border: 1px solid var(--g-color-line-generic);
+  padding: 14px 16px;
+  border: 1px dashed rgba(73, 255, 120, 0.45);
+  background-color: rgba(0, 0, 0, 0.22);
 }
 
 .home-section {
   padding: clamp(24px, 4vw, 40px);
-  background: var(--g-color-base-float);
 }
 
 .home-section--highlight {
   background:
-    radial-gradient(circle at 100% 0%, rgba(43, 198, 118, 0.18), transparent 34%),
-    var(--g-color-base-positive-light);
+    repeating-linear-gradient(90deg, rgba(73, 255, 120, 0.07) 0 1px, transparent 1px 22px),
+    rgba(6, 32, 15, 0.82);
 }
 
 .home-section__header {
@@ -341,7 +492,7 @@ a {
 .home-card-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 16px;
+  gap: 14px;
 }
 
 .home-card {
@@ -349,10 +500,9 @@ a {
   align-content: start;
   gap: 14px;
   min-height: 210px;
-  padding: 22px;
-  border: 1px solid var(--g-color-line-generic);
-  border-radius: var(--g-border-radius-2xl);
-  background-color: var(--g-color-base-background);
+  padding: 20px;
+  border: 1px solid rgba(73, 255, 120, 0.34);
+  background-color: rgba(0, 0, 0, 0.24);
 }
 
 .home-card--proof {
@@ -361,13 +511,12 @@ a {
 
 .home-card__number {
   width: fit-content;
-  padding: 6px 10px;
-  border-radius: 999px;
-  color: var(--g-color-text-info);
-  background-color: var(--g-color-base-info-light);
-  font-size: 13px;
+  padding: 4px 8px;
+  color: #07110c;
+  background-color: #49ff78;
+  font-size: 12px;
   font-weight: 700;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.12em;
 }
 
 .home-outcomes {
@@ -380,10 +529,9 @@ a {
   display: flex;
   align-items: flex-start;
   gap: 12px;
-  padding: 18px;
-  border-radius: var(--g-border-radius-2xl);
-  background-color: color-mix(in srgb, var(--g-color-base-background) 76%, transparent);
-  border: 1px solid var(--g-color-line-generic);
+  padding: 16px;
+  border: 1px solid rgba(73, 255, 120, 0.34);
+  background-color: rgba(0, 0, 0, 0.24);
 }
 
 .home-outcome__check {
@@ -391,11 +539,12 @@ a {
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  border-radius: 999px;
-  color: var(--g-color-text-light-primary);
-  background-color: var(--g-color-text-positive);
+  min-width: 28px;
+  height: 22px;
+  padding: 0 6px;
+  color: #07110c;
+  background-color: #49ff78;
+  font-size: 12px;
   font-weight: 700;
 }
 
@@ -406,9 +555,6 @@ a {
   flex-direction: row;
   gap: 24px;
   padding: clamp(24px, 4vw, 40px);
-  background:
-    radial-gradient(circle at 10% 0%, rgba(255, 219, 77, 0.24), transparent 34%),
-    var(--g-color-base-float);
 }
 
 .home-cta > div:first-child {
@@ -428,6 +574,7 @@ a {
   margin: 0 8px;
   display: inline-block;
   transform: rotate(3deg);
+  filter: sepia(1) saturate(7) hue-rotate(72deg) brightness(1.2) drop-shadow(0 0 7px rgba(73, 255, 120, 0.7));
   transition: transform 0.3s ease;
 }
 
@@ -440,14 +587,58 @@ a {
   flex-wrap: wrap;
   justify-content: flex-start;
   gap: 24px;
-  border-radius: var(--g-border-radius-2xl);
-  padding: 24px;
-  background-color: var(--g-color-base-positive-light);
+  padding: 20px;
 }
 
 .home-socials {
   width: 100%;
   max-width: 1040px;
+}
+
+.home-page + .group-container {
+  padding: 20px;
+  color: #49ff78;
+  font-family: var(--font-mono), "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  text-shadow: 0 0 7px rgba(73, 255, 120, 0.48);
+  background-color: #07110c;
+}
+
+.home-page + .group-container > .g-text::before {
+  content: "$ ls ./pet-projects";
+  display: block;
+  margin-bottom: 10px;
+  color: rgba(190, 255, 199, 0.88);
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.home-page ~ .group-container .project-card {
+  color: #49ff78;
+  min-height: 76px;
+  padding: 18px;
+  transition: transform 0.18s ease, background-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.home-page ~ .group-container .project-card:hover {
+  transform: translateX(6px);
+  background-color: rgba(73, 255, 120, 0.08);
+  box-shadow: 0 0 24px rgba(73, 255, 120, 0.16);
+}
+
+.home-page ~ .group-container .project-card .g-text::before {
+  content: "./";
+  color: rgba(190, 255, 199, 0.88);
+}
+
+@keyframes terminal-cursor {
+  0%, 45% {
+    opacity: 1;
+  }
+
+  46%, 100% {
+    opacity: 0;
+  }
 }
 
 @media (max-width: 960px) {
@@ -474,14 +665,15 @@ a {
 
 @media (max-width: 640px) {
   .home-page {
-    padding-top: 0;
+    padding: 14px;
   }
 
-  .home-hero__content,
-  .home-hero-card,
-  .home-section,
-  .home-cta {
-    border-radius: 24px;
+  .home-terminal-bar {
+    grid-template-columns: auto 1fr;
+  }
+
+  .home-terminal-bar span:nth-child(n + 3) {
+    display: none;
   }
 
   .home-actions,


### PR DESCRIPTION
### Motivation
- Придать главной странице атмосферу старого Unix-терминала: терминальная панель, моноширинный зелёный текст, курсор и псевдо‑команды для визуального акцента. 
- Сделать блок с pet projects частью «терминальной» сцены, чтобы проекты выглядели как вывод команды `ls` и были более заметны.

### Description
- Обновлена разметка `app/HomeClient.tsx`: добавлена верхняя `home-terminal-bar`, несколько декоративных строк-команд (`$ cat`, `$ run`, `$ ls`, `$ tail`, `$ grep`, `$ ./connect`), и упрощены ссылки в секции социальных сетей. 
- Переработан глобальный CSS в `styles/globals.css` с новым набором правил для `.home-page` и связанных классов: моноширинный шрифт, зелёный CRT-стиль, «scanlines»/noise overlay, glow, жесткие панели, терминальный курсор и адаптивные правки. 
- Упрощены и почищены компоненты: `app/components/MyProjects/MyProjects.tsx` и `app/components/show-app/ShowApp.tsx` (удалены неиспользуемые импорты, приведение верстки к единому стилю карточек). 
- Мелкие правки: замены текста/символов в карточках (например, чек ↦ `OK` в терминальном стиле) и aria‑атрибуты для декоративных элементов.

### Testing
- Выполнена проверка изменений с `git diff --check` (успешно). 
- Запуск dev-сервера с фиктивными переменными окружения `NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run dev` и проверка главной страницы через `curl -s -o /tmp/home.html -w "%{http_code}\n" http://localhost:3000/` вернули HTTP `200` (успешно).
- Пробный продакшен‑build `npm run build` завершился с ошибками сборки в этой среде из-за отсутствующих некоторых зависимостей/пакетов и проблем с загрузкой Google Fonts (не удалось завершить).
- Статическая проверка типов `npx tsc --noEmit --pretty false` завершилась с ошибками из‑за отсутствующих type definition файлов (`is-number`, `js-cookie`) в текущем окружении (неуспешно).
- ESLint запуск `npx eslint app/HomeClient.tsx app/components/MyProjects/MyProjects.tsx app/components/show-app/ShowApp.tsx` не был выполнен из‑за отсутствия требуемой конфигурации ESLint v9 в этом окружении (неуспешно).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0230dab5f083298d499a20b15957d8)