### PR TITLE
Add tests for transliterate, useBroadcastForm, and BroadcastApi

### DIFF
--- a/features/broadcast-form/model/__tests__/useBroadcastForm.test.ts
+++ b/features/broadcast-form/model/__tests__/useBroadcastForm.test.ts
@@ -1,0 +1,193 @@
+import { renderHook, act } from '@testing-library/react';
+import { useBroadcastForm } from '../useBroadcastForm';
+import { BroadcastApi } from '@/shared/api/broadcast';
+import { useToast } from '@/hooks/use-toast';
+import { useI18n } from '@/app/contexts/I18nContext';
+
+jest.mock('@/shared/api/broadcast');
+jest.mock('@/hooks/use-toast');
+jest.mock('@/app/contexts/I18nContext');
+
+const mockToast = jest.fn();
+const mockBroadcastApi = BroadcastApi as jest.Mocked<typeof BroadcastApi>;
+const mockUseToast = useToast as jest.MockedFunction<typeof useToast>;
+const mockUseI18n = useI18n as jest.MockedFunction<typeof useI18n>;
+
+const broadcastData = {
+  subject: 'Test subject',
+  content: 'Test content',
+  recipients: ['a@example.com'],
+  status: 'draft' as const,
+  scheduled_for: null,
+};
+
+const mockBroadcast = {
+  id: 'bc-1',
+  ...broadcastData,
+  content_html: '<p>Test content</p>',
+  user_id: 'user-1',
+  created_at: '2024-01-01',
+  updated_at: '2024-01-01',
+  sent_at: null,
+  broadcast_id: null,
+  total_recipients: 1,
+  opened_count: 0,
+  clicked_count: 0,
+};
+
+describe('useBroadcastForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseToast.mockReturnValue({ toast: mockToast } as any);
+    mockUseI18n.mockReturnValue({ t: (key: string) => key, language: 'en', setLanguage: jest.fn() });
+  });
+
+  describe('initial state', () => {
+    it('starts with isSubmitting false', () => {
+      const { result } = renderHook(() => useBroadcastForm());
+      expect(result.current.isSubmitting).toBe(false);
+    });
+  });
+
+  describe('saveAsDraft', () => {
+    it('creates broadcast with draft status and shows success toast', async () => {
+      mockBroadcastApi.createBroadcast = jest.fn().mockResolvedValue({ data: mockBroadcast });
+
+      const { result } = renderHook(() => useBroadcastForm());
+
+      await act(async () => {
+        await result.current.saveAsDraft(broadcastData);
+      });
+
+      expect(mockBroadcastApi.createBroadcast).toHaveBeenCalledWith({
+        ...broadcastData,
+        status: 'draft',
+        scheduled_for: null,
+      });
+      expect(mockToast).toHaveBeenCalledWith(expect.objectContaining({ title: 'broadcast.toast.success' }));
+      expect(result.current.isSubmitting).toBe(false);
+    });
+
+    it('shows error toast and re-throws on failure', async () => {
+      mockBroadcastApi.createBroadcast = jest.fn().mockRejectedValue(new Error('Network error'));
+
+      const { result } = renderHook(() => useBroadcastForm());
+
+      let caughtError: Error | undefined;
+      await act(async () => {
+        try { await result.current.saveAsDraft(broadcastData); }
+        catch (e) { caughtError = e as Error; }
+      });
+
+      expect(caughtError?.message).toBe('Network error');
+      expect(mockToast).toHaveBeenCalledWith(expect.objectContaining({ variant: 'destructive' }));
+      expect(result.current.isSubmitting).toBe(false);
+    });
+  });
+
+  describe('updateDraft', () => {
+    it('updates broadcast with draft status and shows success toast', async () => {
+      mockBroadcastApi.updateBroadcast = jest.fn().mockResolvedValue({ data: mockBroadcast });
+
+      const { result } = renderHook(() => useBroadcastForm());
+
+      await act(async () => {
+        await result.current.updateDraft('bc-1', broadcastData);
+      });
+
+      expect(mockBroadcastApi.updateBroadcast).toHaveBeenCalledWith('bc-1', {
+        ...broadcastData,
+        status: 'draft',
+        scheduled_for: null,
+      });
+      expect(mockToast).toHaveBeenCalledWith(expect.objectContaining({ title: 'broadcast.toast.success' }));
+    });
+  });
+
+  describe('scheduleBroadcast', () => {
+    it('creates broadcast with scheduled status and ISO date', async () => {
+      mockBroadcastApi.createBroadcast = jest.fn().mockResolvedValue({ data: mockBroadcast });
+      const scheduleDate = new Date('2024-06-01T10:00:00.000Z');
+
+      const { result } = renderHook(() => useBroadcastForm());
+
+      await act(async () => {
+        await result.current.scheduleBroadcast(broadcastData, scheduleDate);
+      });
+
+      expect(mockBroadcastApi.createBroadcast).toHaveBeenCalledWith({
+        ...broadcastData,
+        status: 'scheduled',
+        scheduled_for: scheduleDate.toISOString(),
+      });
+    });
+  });
+
+  describe('updateSchedule', () => {
+    it('updates broadcast with scheduled status and new date', async () => {
+      mockBroadcastApi.updateBroadcast = jest.fn().mockResolvedValue({ data: mockBroadcast });
+      const scheduleDate = new Date('2024-06-01T10:00:00.000Z');
+
+      const { result } = renderHook(() => useBroadcastForm());
+
+      await act(async () => {
+        await result.current.updateSchedule('bc-1', broadcastData, scheduleDate);
+      });
+
+      expect(mockBroadcastApi.updateBroadcast).toHaveBeenCalledWith('bc-1', {
+        ...broadcastData,
+        status: 'scheduled',
+        scheduled_for: scheduleDate.toISOString(),
+      });
+    });
+  });
+
+  describe('sendNow', () => {
+    it('creates broadcast then sends it', async () => {
+      mockBroadcastApi.createBroadcast = jest.fn().mockResolvedValue({ data: mockBroadcast });
+      mockBroadcastApi.sendBroadcast = jest.fn().mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useBroadcastForm());
+
+      await act(async () => {
+        await result.current.sendNow(broadcastData);
+      });
+
+      expect(mockBroadcastApi.createBroadcast).toHaveBeenCalledWith(broadcastData);
+      expect(mockBroadcastApi.sendBroadcast).toHaveBeenCalledWith('bc-1');
+      expect(mockToast).toHaveBeenCalledWith(expect.objectContaining({ title: 'broadcast.toast.success' }));
+    });
+
+    it('shows error toast if sendBroadcast fails', async () => {
+      mockBroadcastApi.createBroadcast = jest.fn().mockResolvedValue({ data: mockBroadcast });
+      mockBroadcastApi.sendBroadcast = jest.fn().mockRejectedValue(new Error('Send failed'));
+
+      const { result } = renderHook(() => useBroadcastForm());
+
+      let caughtError: Error | undefined;
+      await act(async () => {
+        try { await result.current.sendNow(broadcastData); }
+        catch (e) { caughtError = e as Error; }
+      });
+
+      expect(caughtError?.message).toBe('Send failed');
+      expect(mockToast).toHaveBeenCalledWith(expect.objectContaining({ variant: 'destructive' }));
+    });
+  });
+
+  describe('updateAndSend', () => {
+    it('updates broadcast then sends it', async () => {
+      mockBroadcastApi.updateBroadcast = jest.fn().mockResolvedValue({ data: mockBroadcast });
+      mockBroadcastApi.sendBroadcast = jest.fn().mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useBroadcastForm());
+
+      await act(async () => {
+        await result.current.updateAndSend('bc-1', broadcastData);
+      });
+
+      expect(mockBroadcastApi.updateBroadcast).toHaveBeenCalledWith('bc-1', broadcastData);
+      expect(mockBroadcastApi.sendBroadcast).toHaveBeenCalledWith('bc-1');
+    });
+  });
+});

--- a/lib/__tests__/transliterate.test.ts
+++ b/lib/__tests__/transliterate.test.ts
@@ -1,0 +1,51 @@
+import { transliterate } from '../transliterate';
+
+describe('transliterate', () => {
+  it('converts basic lowercase Cyrillic to Latin', () => {
+    expect(transliterate('привет')).toBe('privet');
+  });
+
+  it('converts uppercase Cyrillic to lowercase Latin', () => {
+    expect(transliterate('ПРИВЕТ')).toBe('privet');
+  });
+
+  it('leaves Latin characters unchanged', () => {
+    expect(transliterate('hello')).toBe('hello');
+  });
+
+  it('leaves numbers and punctuation unchanged', () => {
+    expect(transliterate('123 !@#')).toBe('123 !@#');
+  });
+
+  it('converts multi-char sequences correctly', () => {
+    expect(transliterate('ж')).toBe('zh');
+    expect(transliterate('ш')).toBe('sh');
+    expect(transliterate('щ')).toBe('shch');
+    expect(transliterate('ц')).toBe('ts');
+    expect(transliterate('ч')).toBe('ch');
+    expect(transliterate('ю')).toBe('yu');
+    expect(transliterate('я')).toBe('ya');
+    expect(transliterate('ё')).toBe('yo');
+  });
+
+  it('drops soft sign', () => {
+    expect(transliterate('ь')).toBe('');
+    expect(transliterate('мать')).toBe('mat');
+  });
+
+  it('drops hard sign', () => {
+    expect(transliterate('ъ')).toBe('');
+  });
+
+  it('handles mixed Cyrillic and Latin', () => {
+    expect(transliterate('React компонент')).toBe('React komponent');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(transliterate('')).toBe('');
+  });
+
+  it('converts a full sentence correctly', () => {
+    expect(transliterate('Новый пост')).toBe('novyy post');
+  });
+});

--- a/lib/transliterate.ts
+++ b/lib/transliterate.ts
@@ -15,7 +15,7 @@ export function transliterate(text: string): string {
     'Ъ': '', 'Ы': 'y', 'Ь': '', 'Э': 'e', 'Ю': 'yu', 'Я': 'ya'
   };
 
-  return text.split('').map(char => 
-    cyrillicMap[char] || char
+  return text.split('').map(char =>
+    char in cyrillicMap ? cyrillicMap[char] : char
   ).join('');
 }

--- a/shared/api/__tests__/broadcast.test.ts
+++ b/shared/api/__tests__/broadcast.test.ts
@@ -1,0 +1,141 @@
+import { BroadcastApi } from '../broadcast';
+
+const mockResponse = (body: unknown, status = 200) =>
+  Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: () => Promise.resolve(body),
+  });
+
+describe('BroadcastApi', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('getBroadcasts', () => {
+    it('calls /api/broadcasts with no query string when no filters', async () => {
+      (global.fetch as jest.Mock).mockReturnValue(mockResponse({ data: [], count: 0 }));
+
+      await BroadcastApi.getBroadcasts();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/broadcasts',
+        expect.objectContaining({ credentials: 'include' })
+      );
+    });
+
+    it('appends single status filter to URL', async () => {
+      (global.fetch as jest.Mock).mockReturnValue(mockResponse({ data: [], count: 0 }));
+
+      await BroadcastApi.getBroadcasts({ status: 'draft' });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/broadcasts?status=draft',
+        expect.anything()
+      );
+    });
+
+    it('appends multiple status values as repeated params', async () => {
+      (global.fetch as jest.Mock).mockReturnValue(mockResponse({ data: [], count: 0 }));
+
+      await BroadcastApi.getBroadcasts({ status: ['draft', 'scheduled'] });
+
+      const url = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+      expect(url).toContain('status=draft');
+      expect(url).toContain('status=scheduled');
+    });
+
+    it('appends limit and offset', async () => {
+      (global.fetch as jest.Mock).mockReturnValue(mockResponse({ data: [], count: 0 }));
+
+      await BroadcastApi.getBroadcasts({ limit: 20, offset: 40 });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/broadcasts?limit=20&offset=40',
+        expect.anything()
+      );
+    });
+  });
+
+  describe('getBroadcast', () => {
+    it('calls /api/broadcasts/:id', async () => {
+      (global.fetch as jest.Mock).mockReturnValue(mockResponse({ data: {} }));
+
+      await BroadcastApi.getBroadcast('abc-123');
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/broadcasts/abc-123',
+        expect.anything()
+      );
+    });
+  });
+
+  describe('createBroadcast', () => {
+    it('sends POST with JSON body', async () => {
+      (global.fetch as jest.Mock).mockReturnValue(mockResponse({ data: {} }));
+      const payload = { subject: 'Hello', content: 'Body', recipients: [], status: 'draft' as const, scheduled_for: null };
+
+      await BroadcastApi.createBroadcast(payload);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/broadcasts',
+        expect.objectContaining({ method: 'POST', body: JSON.stringify(payload) })
+      );
+    });
+  });
+
+  describe('deleteBroadcast', () => {
+    it('sends DELETE to /api/broadcasts/:id', async () => {
+      (global.fetch as jest.Mock).mockReturnValue(mockResponse(null, 204));
+
+      await BroadcastApi.deleteBroadcast('abc-123');
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/broadcasts/abc-123',
+        expect.objectContaining({ method: 'DELETE' })
+      );
+    });
+  });
+
+  describe('sendBroadcast', () => {
+    it('sends POST to /api/broadcasts/send with id in body', async () => {
+      (global.fetch as jest.Mock).mockReturnValue(mockResponse(null, 200));
+
+      await BroadcastApi.sendBroadcast('abc-123');
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/broadcasts/send',
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({ id: 'abc-123' }) })
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws with parsed error message on non-ok response', async () => {
+      (global.fetch as jest.Mock).mockReturnValue(
+        mockResponse({ error: 'Not found' }, 404)
+      );
+
+      await expect(BroadcastApi.getBroadcast('missing')).rejects.toThrow('Not found');
+    });
+
+    it('throws unauthorised message on 401', async () => {
+      (global.fetch as jest.Mock).mockReturnValue(
+        mockResponse({ error: 'Unauthorized' }, 401)
+      );
+
+      await expect(BroadcastApi.getBroadcasts()).rejects.toThrow('Не авторизован');
+    });
+
+    it('throws network error message on fetch failure', async () => {
+      (global.fetch as jest.Mock).mockRejectedValue(new TypeError('Failed to fetch'));
+
+      await expect(BroadcastApi.getBroadcasts()).rejects.toThrow('Ошибка сети');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `lib/__tests__/transliterate.test.ts` — 10 тестов: Кириллица→латиница, многосимвольные последовательности (zh/sh/shch/ts/ch), удаление ъ/ь
- `features/broadcast-form/model/__tests__/useBroadcastForm.test.ts` — 9 тестов: все 6 операций формы (saveAsDraft, updateDraft, scheduleBroadcast, updateSchedule, sendNow, updateAndSend) с путями успеха и ошибок
- `shared/api/__tests__/broadcast.test.ts` — 11 тестов: URL-параметры фильтрации, повторяющиеся status-параметры, HTTP-методы/тела, обработка ошибок (401, non-ok, сетевые)

Попутно исправлен баг в `lib/transliterate.ts`: мягкий и твёрдый знаки (ь, ъ) не удалялись, так как их значение `''` — falsy. Изменено с `cyrillicMap[char] || char` на `char in cyrillicMap ? cyrillicMap[char] : char`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6Kgk3QuqYgkXq5r8WCF7G)_