### PR TITLE
fix(blog): persist show_featured_image on create and update

### DIFF
--- a/app/api/blog-posts/[id]/route.ts
+++ b/app/api/blog-posts/[id]/route.ts
@@ -294,7 +294,7 @@ export const PUT = withAuth(async (request: NextRequest, user: { id: string }) =
         });
 
     // Parse the request body
-    const { title, content, excerpt, slug, featured_image, published } = await request.json();
+    const { title, content, excerpt, slug, featured_image, published, show_featured_image } = await request.json();
 
     // Validate required fields
     if (!title?.trim()) {
@@ -376,6 +376,7 @@ export const PUT = withAuth(async (request: NextRequest, user: { id: string }) =
     // Only include optional fields if they are provided
     if (excerpt !== undefined) updateData.excerpt = excerpt;
     if (featured_image !== undefined) updateData.featured_image = normalizedFeatured ?? null;
+    if (show_featured_image !== undefined) updateData.show_featured_image = show_featured_image;
     if (published !== undefined) updateData.published = published;
 
     const { data, error } = await updateClient

--- a/app/api/blog-posts/route.ts
+++ b/app/api/blog-posts/route.ts
@@ -260,6 +260,9 @@ export const POST = withAuth(async (request: NextRequest, user: { id: string }) 
     const featured_image = body.featured_image || url.searchParams.get('featured_image');
     const published = body.published !== undefined ? body.published :
       (url.searchParams.get('published') === 'true');
+    const show_featured_image = body.show_featured_image !== undefined
+      ? body.show_featured_image
+      : (url.searchParams.get('show_featured_image') !== 'false');
     // Validate required fields
     if (!title?.trim()) {
       return NextResponse.json(
@@ -374,6 +377,7 @@ export const POST = withAuth(async (request: NextRequest, user: { id: string }) 
         slug: finalSlug,
         excerpt,
         featured_image: normalizedFeaturedImage ?? null,
+        show_featured_image,
         published,
         author_id: user.id,
         created_at: new Date().toISOString(),


### PR DESCRIPTION
The 'show cover' toggle value was sent by the editor but neither the
POST (create) nor PUT (update) blog-posts API routes read or saved it.
As a result show_featured_image stayed at the DB default (true), so the
cover image remained visible even after unchecking the toggle when adding
or editing a post.

Read show_featured_image from the request body in both routes and persist
it to the blog_posts table.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MEmdK6vhNFMcA1w5MbAt5H