### PR TITLE
Upgrade AI model to gpt-oss:20b and improve Ollama response parsing

### DIFF
--- a/app/api/generate-text-stream/route.ts
+++ b/app/api/generate-text-stream/route.ts
@@ -181,7 +181,7 @@ export async function POST(request: Request) {
               for (const line of lines) {
                 if (!line.trim()) continue;
                 const chunk = JSON.parse(line);
-                const text = chunk.message?.content;
+                const text = chunk.message?.content || chunk.message?.thinking;
                 if (text) controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify({ text })}\n\n`));
               }
             }

--- a/app/api/generate-text/route.ts
+++ b/app/api/generate-text/route.ts
@@ -572,8 +572,9 @@ export async function POST(request: Request) {
       }
 
       const ollamaResult = await ollamaResponse.json();
-      let generatedText = ollamaResult.message?.content;
-      if (!generatedText) throw new Error('No text found in Ollama response');
+      // Reasoning models may place the answer in `thinking` when the token budget is exhausted.
+      let generatedText = ollamaResult.message?.content || ollamaResult.message?.thinking;
+      if (!generatedText) throw new Error('Ollama returned neither message content nor thinking');
 
       if (mode === 'WEB' && webSearchSources.length > 0) {
         generatedText = appendSourcesIfMissing(generatedText, webSearchSources);


### PR DESCRIPTION
- Upgraded the AI model to gpt-oss:20b and improved the model selection logic.
- Enhanced text extraction for Ollama responses to support both 'content' and 'thinking' fields.

[v0 Session](https://v0.app/gareevart/chat/2178Hgxv1FD)